### PR TITLE
Keep leading spaces in Django tags.

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -104,9 +104,17 @@ export const defaultOptions = {
 };
 
 function formatDjangoTag(text) {
-  // Remove all duplicate spaces that are not inside quotes
-  return text.replace(
-    / +(?=([^"\\]*(\\.|"([^"\\]*\\.)*[^"\\]*"))*[^"]*$)/g,
-    " "
-  );
+  const varMatch = text.match(/^\{\{(\w+)\}\}$/);
+  if (varMatch) {
+    return '{{ ' + varMatch[1] + ' }}';
+  }
+  // Remove duplicate spaces that are not leading and inside quotes
+  const tagMatch = text.match(/^(\{% *)(.*)/);
+  if (tagMatch) {
+    return tagMatch[1] + tagMatch[2].replace(
+      / {2,}(?=([^"\\]*(\\.|"([^"\\]*\\.)*[^"\\]*"))*[^"]*$)/g,
+      " "
+    );
+  }
+  return text;
 }


### PR DESCRIPTION
A possible workaround for #1 . I use it almost a year like that and it feels fine.